### PR TITLE
Fix missing dependancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(name='goose',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['PIL', 'lxml']
+    install_requires=['PIL', 'lxml', 'cssselect']
 )


### PR DESCRIPTION
Just got an exception on cssselect missing:

Url: http://liberation.fr.feedsportal.com/c/32268/f/606161/s/250e1316/l/0L0Secrans0Bfr0CImpots0Eune0Eardo

  File "semantism/link.py", line 123, in extract_text_html
    article = self.goose.extractContent(url=url, rawHTML=page_content)

  File "goose/Goose.py", line 52, in extractContent
    return self.sendToActor(cc)

  File "goose/Goose.py", line 59, in sendToActor
    article = crawler.crawl(crawlCandiate)

  File "goose/Crawler.py", line 76, in crawl
    article.metaDescription = extractor.getMetaDescription(article)

  File "goose/extractors.py", line 183, in getMetaDescription
    return self.getMetaContent(article.doc, "meta[name=description]")

  File "goose/extractors.py", line 168, in getMetaContent
    meta = doc.cssselect(metaName)

  File "lxml/html/**init**.py", line 290, in cssselect
    from lxml.cssselect import CSSSelector

  File "/home/benoit/projs/collectr/env/local/lib/python2.7/site-packages/lxml/cssselect.py", line 18, in <module>
    raise ImportError('cssselect seems not to be installed. '
