### PR TITLE
Removing set() Usage in Content Clusterer

### DIFF
--- a/goose/extractors.py
+++ b/goose/extractors.py
@@ -237,7 +237,7 @@ class ContentExtractor(object):
         startingBoost = float(1.0)
         cnt = 0
         i = 0
-        parentNodes = set()
+        parentNodes = []
         nodesWithText = []
 
         for node in nodesToCheck:
@@ -277,7 +277,7 @@ class ContentExtractor(object):
             self.updateNodeCount(node.getparent(), 1)
 
             if node.getparent() not in parentNodes:
-                parentNodes.add(node.getparent())
+                parentNodes.append(node.getparent())
 
             # parentparent node
             parentParentNode = Parser.getParent(parentNode)
@@ -285,7 +285,7 @@ class ContentExtractor(object):
                 self.updateNodeCount(parentParentNode, 1)
                 self.updateScore(parentParentNode, upscore / 2)
                 if parentParentNode not in parentNodes:
-                    parentNodes.add(parentParentNode)
+                    parentNodes.append(parentParentNode)
             cnt += 1
             i += 1
 


### PR DESCRIPTION
set() is unordered, so nodes are reordered relative to their position on the page.
