### PR TITLE
Don't rely on /tmp/goosetmp existing or being writable any more.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .DS_Store*
 env/
 *~
+.idea

--- a/README.md
+++ b/README.md
@@ -139,5 +139,3 @@ Installation Help:
 4. Next up clone this repo and install the egg.
 
 5. Once you install the egg you have to then copy the resources directory manually into the egg.  There is something screwy about the way its setup.
-
-6. Create and chown the Goose temp directory "/tmp/goosetmp"

--- a/goose/configuration.py
+++ b/goose/configuration.py
@@ -20,14 +20,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import tempfile
 from goose.text import StopWords
+
 
 class Configuration(object):
 
     def __init__(self):
         # this is the local storage path used to place
         # images to inspect them, should be writable
-        self.local_storage_path = "/tmp/goosetmp"
+        self.local_storage_path = tempfile.gettempdir()
 
         # What's the minimum bytes for an image we'd accept is,
         # alot of times we want to filter out the author's little images

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,6 +33,24 @@ from goose.text import StopWordsChinese
 CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
+class TestTempDir(unittest.TestCase):
+
+    def test_exception_if_temp_dir_doesnt_exist(self):
+        path = '/this/directory/does/not/exist/i/assume/'
+        config = Configuration()
+        config.local_storage_path = path
+        self.assertRaises(Exception, lambda: Goose(config=config))
+
+    def test_no_exception_if_temp_dir_exists(self):
+        import tempfile
+        config = Configuration()
+        config.local_storage_path = tempfile.gettempdir()
+        try:
+            Goose(config=config)
+        except:
+            self.fail()
+
+
 class TestParser(unittest.TestCase):
 
     def get_html(self, filename):


### PR DESCRIPTION
Requiring /tmp/goosetmp to exist and be writable was becoming a problem, it was easy for that directory to disappear or somehow get the wrong permissions when deploying.  I changed this to use Python's tempfile module to determine an appropriate temporary directory.
