### PR TITLE
Handle missing src attribute values for known image elements.

### DIFF
--- a/goose/images/extractors.py
+++ b/goose/images/extractors.py
@@ -386,7 +386,8 @@ class UpgradedImageIExtractor(ImageExtractor):
             image = _check_elements(elements)
             if image is not None:
                 src = self.parser.getAttribute(image, attr='src')
-                return self.get_image(image, src, score=90, extraction_type='known')
+                if src:
+                    return self.get_image(image, src, score=90, extraction_type='known')
 
         # check for elements with known classes
         for css in KNOWN_IMG_DOM_NAMES:
@@ -394,9 +395,10 @@ class UpgradedImageIExtractor(ImageExtractor):
             image = _check_elements(elements)
             if image is not None:
                 src = self.parser.getAttribute(image, attr='src')
-                return self.get_image(image, src, score=90, extraction_type='known')
+                if src:
+                    return self.get_image(image, src, score=90, extraction_type='known')
 
-        return image
+        return None
 
     def build_image_path(self, src):
         """\

--- a/tests/data/images/test_known_image_empty_src/test_known_image_empty_src.html
+++ b/tests/data/images/test_known_image_empty_src/test_known_image_empty_src.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/loose.dtd"><html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+
+    <body>
+        <div>
+            <img class="storytext" src="http://bla.com/images/465395/"/>
+        </div>
+        <div>
+            <img class="mediaimage" src=""/>
+        </div>
+        <div>
+            <h1>title</h1>
+            <p>
+                TextNode 1 - The Scala supported IDE is one of the few pain points of developers who want to start using Scala in their Java project. On existing long term project developed by a team its hard to step in and introduce a new language that is not supported by the existing IDE. On way to go about it is to hid the fact that you use Scala from the Java world by using one way dependency injection. Still, if you wish to truly absorb Scala into your existing java environment then you'll soon introduced cross language dependencies.
+            </p>
+            <p>
+                Most of our team is using Eclipse as the main IDE, its incrimental compilation in Java with its tight JUnit integration are great for fast TDD programming. Unfortunately the Eclipse Scala plugin is not there yet, it may hangs the IDE and messes up Java compilation - especially in large (more then 1000 source files) Java/Scala projects. Though the plugin is getting better over time some developers would find the plugin as a majore drag on their productivity.
+                For developers who do not write Scala at all or rather edit Scala with other editors, you can use this alternate path which lets them work on their Java or Scala code without messing with the plugin.
+            </p>
+        </div>
+    </body>
+</html>

--- a/tests/data/images/test_known_image_empty_src/test_known_image_empty_src.json
+++ b/tests/data/images/test_known_image_empty_src/test_known_image_empty_src.json
@@ -1,0 +1,15 @@
+{
+    "url": "http://go.com/bla/bla",
+    "expected": {
+        "cleaned_text" : "TextNode 1 - The Scala supported IDE is one of the few pain points of developers who want to start u",
+        "top_image": {
+            "extraction_type": "NA",
+            "src": "",
+            "confidence_score": 0.0,
+            "bytes": 0,
+            "height": 0,
+            "width": 0,
+            "top_image_node": null
+        }
+    }
+}

--- a/tests/images.py
+++ b/tests/images.py
@@ -144,6 +144,11 @@ class ImageExtractionTests(TestExtractionBase):
         article = self.getArticle()
         self._test_known_image_css(article)
 
+    def test_known_image_empty_src(self):
+        'Tests that img tags for known image sources with empty src attributes are skipped.'
+        article = self.getArticle()
+        self._test_known_image_css(article)
+
     def test_opengraph_tag(self):
         article = self.getArticle()
         self._test_known_image_css(article)


### PR DESCRIPTION
Calls to UpgradedImageIExtractor.get_image in check_known_elements
were not checking the validity of the extracted src before trying to
use it to build the image. This caused an exception when build_image
tried to parse the src URL.
