### PR TITLE
Fix for bigimage width/height and basic image test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ env/
 *~
 .idea
 ._*
+venv/
+goose_extractor.egg-info/

--- a/goose/images/extractors.py
+++ b/goose/images/extractors.py
@@ -128,7 +128,9 @@ class UpgradedImageIExtractor(ImageExtractor):
                                         key=lambda x: x[1], reverse=True)[0][0]
                 main_image = Image()
                 main_image.src = highscore_image.src
-                main_image.extraction_type = "bigimage"
+                main_image.width = highscore_image.width
+                main_image.height = highscore_image.height
+		main_image.extraction_type = "bigimage"
                 main_image.confidence_score = 100 / len(scored_images) \
                                     if len(scored_images) > 0 else 0
                 return main_image

--- a/tests/data/images/test_basic_image/test_basic_image.json
+++ b/tests/data/images/test_basic_image/test_basic_image.json
@@ -6,8 +6,8 @@
             "src": "http://md0.libe.com/photo/465395/?modified_at=1351411813&ratio_x=03&ratio_y=02&width=476", 
             "confidence_score": 100, 
             "bytes": 0, 
-            "height": 0, 
-            "width": 0, 
+            "height": 317, 
+            "width": 476, 
             "top_image_node": null
         }
     }


### PR DESCRIPTION
This simple change is the same change as Issue #49 except that I changed the basic image test so that it checks for the correct image dimensions (instead of 0 width 0 height). It also resolves Issue #44.
