### PR TITLE
Testing for OSError when deleting test.txt

### DIFF
--- a/goose/__init__.py
+++ b/goose/__init__.py
@@ -84,3 +84,8 @@ class Goose(object):
                 " directory is not writeble, "
                 "you need to set this for image processing downloads"
             )
+        except OSError:
+            # it is possible that in cases where goose is running concurrently
+            # previous process may delete test.txt file which will cause current 
+            # process to raise OSError.
+            pass


### PR DESCRIPTION
It is possible that in cases where goose is running concurrently previous process may delete test.txt file which will cause current process to raise OSError.
