### PR TITLE
fixed issue with the meta language not being set in the extractor

### DIFF
--- a/goose/crawler.py
+++ b/goose/crawler.py
@@ -97,7 +97,7 @@ class Crawler(object):
                 image_extractor = self.get_image_extractor(article)
                 article.top_image = image_extractor.get_best_image(article.raw_doc, article.top_node)
             # post cleanup
-            article.top_node = extractor.post_cleanup(article.top_node)
+            article.top_node = extractor.post_cleanup(article.top_node, article)
             # clean_text
             article.cleaned_text = output_formatter.get_formatted_text(article)
 

--- a/goose/outputformatters.py
+++ b/goose/outputformatters.py
@@ -43,6 +43,7 @@ class OutputFormatter(object):
         if self.config.use_meta_language == True:
             if article.meta_lang:
                 return article.meta_lang[:2]
+
         return self.config.target_language
 
     def get_top_node(self):


### PR DESCRIPTION
Even if `use_meta_language` was set to `True`, the meta language was not used by the extractor, because the extractor always used `self.language`, which was set to `config.target_language`.
I had the problem that a spanish website was not correctly parsed until I forced the language to "es", even that the correct meta_lang was found by Goose.
