### PR TITLE
Make local_storage_path configurable.

### DIFF
--- a/goose/configuration.py
+++ b/goose/configuration.py
@@ -83,10 +83,10 @@ class Configuration(object):
 
         # Parser type
         self.parser_class = 'lxml'
-
-    @property
-    def local_storage_path(self):
-        return os.path.join(tempfile.gettempdir(), 'goose')
+        
+        # set the local storage path
+        # make this configurable
+        self.local_storage_path = os.path.join(tempfile.gettempdir(), 'goose')
 
     def get_parser(self):
         return Parser if self.parser_class == 'lxml' else ParserSoup


### PR DESCRIPTION
Heroku and other systems don't support writing to /tmp.
So the local_storage_path property should be exposable.

See https://github.com/grangier/python-goose/issues/61

This fixes the pull request https://github.com/grangier/python-goose/pull/85
