### PR TITLE
Add bounds check to index access.

### DIFF
--- a/goose/cleaners.py
+++ b/goose/cleaners.py
@@ -84,7 +84,8 @@ class DocumentCleaner(object):
         # in case it matches an unwanted class all the document
         # will be empty
         elements = self.parser.getElementsByTag(doc, tag="body")
-        self.parser.delAttribute(elements[0], attr="class")
+        if elements:
+            self.parser.delAttribute(elements[0], attr="class")
         return doc
 
     def clean_article_tags(self, doc):


### PR DESCRIPTION
Received a number of exceptions from this piece of code
due to `elements` being empty. Add a check for elements
being empty.
