### PR TITLE
BugFix: wrong equality comparision

### DIFF
--- a/goose/extractors.py
+++ b/goose/extractors.py
@@ -491,7 +491,7 @@ class ContentExtractor(object):
                 self.parser.remove(p)
 
         subParagraphs2 = self.parser.getElementsByTag(e, tag='p')
-        if len(subParagraphs2) == 0 and e.tag is not "td":
+        if len(subParagraphs2) == 0 and e.tag != "td":
             return True
         return False
 


### PR DESCRIPTION
I think the equality comparison is wrong. Therefore goose was not able to extract text when the main text is in "td".  

For eg: http://www.bangalore.philips.com/html/index.asp . 

After this fix, it works fine. 
