### PR TITLE
Replaced bare except with except Exception

### DIFF
--- a/goose/images/utils.py
+++ b/goose/images/utils.py
@@ -119,5 +119,5 @@ class ImageUtils(object):
             f = urllib2.urlopen(req)
             data = f.read()
             return data
-        except:
+        except Exception:
             return None

--- a/goose/network.py
+++ b/goose/network.py
@@ -51,7 +51,7 @@ class HtmlFetcher(object):
             self.result = urllib2.urlopen(
                             self.request,
                             timeout=self.config.http_timeout)
-        except:
+        except Exception:
             self.result = None
 
         # read the result content

--- a/goose/text.py
+++ b/goose/text.py
@@ -46,7 +46,7 @@ def encodeValue(value):
         value = smart_unicode(value)
     except (UnicodeEncodeError, DjangoUnicodeDecodeError):
         value = smart_str(value)
-    except:
+    except Exception:
         value = string_org
     return value
 

--- a/goose/version.py
+++ b/goose/version.py
@@ -21,5 +21,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-version_info = (1, 0, 22)
+version_info = (1, 0, 23)
 __version__ = ".".join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ description = "Html Content / Article Extractor, web scrapping"
 try:
     with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
         long_description = f.read()
-except:
+except Exception:
     long_description = description
 
 setup(name='goose-extractor',


### PR DESCRIPTION
This was required to get [gevent.Timeout](http://www.gevent.org/gevent.html#timeouts)'s working:

```
with gevent.Timeout(10):
    goose.extract('http://example.com')
```

Without that, Timeout instance raised by gevent was catched by bare except, and there was no way to abort this code execution.

It is a bad practice to use bare except, since there are some exceptions like GeneratorExit, KeyboardInterrupt, SystemExit which are not errors, but still could be thrown in any part of the code, and usually you should not catch them.
