### PR TITLE
Fix bug with site_name=None

### DIFF
--- a/goose/extractors/title.py
+++ b/goose/extractors/title.py
@@ -37,7 +37,7 @@ class TitleExtractor(BaseExtractor):
         """
         # check if we have the site name in opengraph data
         if "site_name" in self.article.opengraph.keys():
-            site_name = self.article.opengraph['site_name']
+            site_name = self.article.opengraph['site_name'] or ''
             # remove the site name from title
             title = title.replace(site_name, '').strip()
 


### PR DESCRIPTION
When og:site_name is null a ValueError occurs when attempting str.replace.

Stack trace:

```
In [3]: g.extract('https://blog.kissmetrics.com/tracking-marketing-campaigns/')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-98471b35ffad> in <module>()
----> 1 g.extract('https://blog.kissmetrics.com/tracking-marketing-campaigns/')

/home/yuri/repos/python-goose/goose/__init__.pyc in extract(self, url, raw_html)
     54         """
     55         cc = CrawlCandidate(self.config, url, raw_html)
---> 56         return self.crawl(cc)
     57 
     58     def shutdown_network(self):

/home/yuri/repos/python-goose/goose/__init__.pyc in crawl(self, crawl_candiate)
     64         try:
     65             crawler = Crawler(self.config)
---> 66             article = crawler.crawl(crawl_candiate)
     67         except (UnicodeDecodeError, ValueError):
     68             self.config.parser_class = parsers[0]

/home/yuri/repos/python-goose/goose/crawler.pyc in crawl(self, crawl_candidate)
    152 
    153         # title
--> 154         self.article.title = self.title_extractor.extract()
    155 
    156         # check for known node as content body

/home/yuri/repos/python-goose/goose/extractors/title.py in extract(self)
    102 
    103     def extract(self):
--> 104         return self.get_title()

/home/yuri/repos/python-goose/goose/extractors/title.py in get_title(self)
     81         if "title" in self.article.opengraph.keys():
     82             title = self.article.opengraph['title']
---> 83             return self.clean_title(title)
     84 
     85         # try to fetch the meta headline

/home/yuri/repos/python-goose/goose/extractors/title.py in clean_title(self, title)
     40             site_name = self.article.opengraph['site_name']
     41             # remove the site name from title
---> 42             title = title.replace(site_name, '').strip()
     43 
     44         # try to remove the domain from url

TypeError: expected a character buffer object
```
