### PR TITLE
Hotfix for #219 - Missing real fix

### DIFF
--- a/goose/crawler.py
+++ b/goose/crawler.py
@@ -181,6 +181,7 @@ class Crawler(object):
 
             # image handling
             if self.config.enable_image_fetching:
+                self.image_extractor = self.get_image_extractor() # Hotfix for #219
                 self.get_image()
 
             # post cleanup


### PR DESCRIPTION
Here the image extractor was initialized before the real scrape. So no information was store in self.article. This correction is ugly, and might benefit from a different fix.
