### PR TITLE
add gzip deflation to HtmlFetcher

### DIFF
--- a/goose/network.py
+++ b/goose/network.py
@@ -21,6 +21,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import urllib2
+import zlib
 
 
 class HtmlFetcher(object):
@@ -56,5 +57,7 @@ class HtmlFetcher(object):
 
         # read the result content
         if self.result is not None:
+            if self.result.info().get('Content-Encoding') == 'gzip':
+                return zlib.decompress(self.result.read(), zlib.MAX_WBITS | 16)
             return self.result.read()
         return None

--- a/tests/extractors/base.py
+++ b/tests/extractors/base.py
@@ -25,6 +25,7 @@ import json
 import urllib2
 import unittest
 import socket
+import mimetools
 
 from StringIO import StringIO
 
@@ -53,7 +54,8 @@ class MockResponse():
     def response(self, req):
         data = self.content(req)
         url = req.get_full_url()
-        resp = urllib2.addinfourl(StringIO(data), data, url)
+        headers = mimetools.Message(StringIO(''))
+        resp = urllib2.addinfourl(StringIO(data), headers, url)
         resp.code = self.code
         resp.msg = self.msg
         return resp


### PR DESCRIPTION
Had problems with a site that forced gzip compression, so I suggest this kind of solution. This'd resolve [issue #238](https://github.com/grangier/python-goose/issues/238).
