### PR TITLE
Not working on some urls

### DIFF
--- a/goose/text.py
+++ b/goose/text.py
@@ -94,8 +94,12 @@ class StopWords(object):
         # TODO replace 'x' with class
         # to generate dynamic path for file to load
         if not language in self._cached_stop_words:
-            path = os.path.join('text', 'stopwords-%s.txt' % language)
-            self._cached_stop_words[language] = set(FileHelper.loadResourceFile(path).splitlines())
+            try:
+                path = os.path.join('text', 'stopwords-%s.txt' % language)
+                self._cached_stop_words[language] = set(FileHelper.loadResourceFile(path).splitlines())
+            except Exception:
+                path = os.path.join('text', 'stopwords-en.txt')
+                self._cached_stop_words[language] = set(FileHelper.loadResourceFile(path).splitlines())
         self.STOP_WORDS = self._cached_stop_words[language]
 
     def remove_punctuation(self, content):


### PR DESCRIPTION
It doesn't work http://www.highbeam.com/doc/1P3-979471971.html
Though adding 
KNOWN_ARTICLE_CONTENT_TAGS = [
    {'attr': 'id', 'value': 'docText'},
    ... other paths go here
]
in the orginial repo does the job. I am unable to find a way to achieve the same here.
http://stackoverflow.com/questions/30381944/read-article-content-using-goose-retrieving-nothing/30408761?noredirect=1#comment51989019_30408761
