### PR TITLE
Fallback to 'http' as default url schema if needed

### DIFF
--- a/goose/__init__.py
+++ b/goose/__init__.py
@@ -22,6 +22,7 @@ limitations under the License.
 """
 import os
 import platform
+import urllib2
 from tempfile import mkstemp
 
 from goose.version import version_info, __version__
@@ -52,6 +53,11 @@ class Goose(object):
         Main method to extract an article object from a URL,
         pass in a url and get back a Article
         """
+        scheme, address = urllib2.splittype(url)
+
+        if not scheme:
+            url = self.config.default_scheme + url
+
         cc = CrawlCandidate(self.config, url, raw_html)
         return self.crawl(cc)
 

--- a/goose/configuration.py
+++ b/goose/configuration.py
@@ -99,6 +99,10 @@ class Configuration(object):
         # http timeout
         self.http_timeout = HTTP_DEFAULT_TIMEOUT
 
+        # default url scheme
+        # it will be use as fallback if url doesnt conain one
+        self.default_scheme = 'http://'
+
     def get_parser(self):
         return AVAILABLE_PARSERS[self.parser_class]
 


### PR DESCRIPTION
I have noticed that goose is not playing well with urls without proper schema so i created this fix. 
I'm not sure if this check/fix is necessary on library level, but it was interesting fix for one python beginner.
