### PR TITLE
Travis Bugfix: No More `--use-mirrors` Option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - 2.7
 
 install:
-    - pip install -r requirements.txt --use-mirrors
+    - pip install -r requirements.txt
     - python setup.py install
 
 script: python setup.py test


### PR DESCRIPTION
Option `--use-mirrors` have been deprecated in `pip` since version
7.0.0. This will cause the Travis check to be failed for any new pull
request.
