### PR TITLE
remove use-mirror as it is depriciated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - 2.7
 
 install:
-    - pip install -r requirements.txt --use-mirrors
+    - pip install -r requirements.txt
     - python setup.py install
 
 script: python setup.py test


### PR DESCRIPTION
As per the following: pypa/pip#1098

The --use-mirrors argument for travis.yml was deprecated in 2015. Due to this tests are failing.