### PR TITLE
added support for HTTP and HTTPS proxy. 

### DIFF
--- a/goose/configuration.py
+++ b/goose/configuration.py
@@ -99,6 +99,10 @@ class Configuration(object):
         # http timeout
         self.http_timeout = HTTP_DEFAULT_TIMEOUT
 
+        # proxy settings
+        self.http_proxy = None
+        self.https_proxy = None
+
     def get_parser(self):
         return AVAILABLE_PARSERS[self.parser_class]
 

--- a/goose/network.py
+++ b/goose/network.py
@@ -30,6 +30,16 @@ class HtmlFetcher(object):
         # set header
         self.headers = {'User-agent': self.config.browser_user_agent}
 
+        proxies = {}
+        if self.config.http_proxy is not None:
+            proxies["http"] = self.config.http_proxy;
+        if self.config.https_proxy is not None:
+            proxies["https"] = self.config.https_proxy;
+        if len(proxies) > 0:
+            proxy = urllib2.ProxyHandler(proxies)
+            opener = urllib2.build_opener(proxy)
+            urllib2.install_opener(opener)
+
     def get_url(self):
         # if we have a result
         # get the final_url


### PR DESCRIPTION
#283 

example usage:

`g = Goose( {'https_proxy' : '127.0.0.1:8080'} )` 